### PR TITLE
doc_to_ids Performance Improve

### DIFF
--- a/lda/vocabulary.py
+++ b/lda/vocabulary.py
@@ -65,9 +65,10 @@ class Vocabulary:
             id = self.term_to_id(term)
             if id != None:
                 list.append(id)
-                words[id] = 1
+                if not words.has_key(id):
+                    words[id] = 1
+                    self.docfreq[id] += 1
         if "close" in dir(doc): doc.close()
-        for id in words: self.docfreq[id] += 1
         return list
 
     def cut_low_freq(self, corpus, threshold=1):


### PR DESCRIPTION
Added a condition to verify if the term id is not in the 'words' dictionary and removed the last for loop in the function doc_to_ids.

This improves the performance of that function, avoiding to the extra for loop at the end.
