### PR TITLE
Do range checking on gammaln

### DIFF
--- a/lda/hdplda2.py
+++ b/lda/hdplda2.py
@@ -7,7 +7,14 @@
 # (refer to "Hierarchical Dirichlet Processes"(Teh et.al, 2005))
 
 import numpy
-from scipy.special import gammaln
+from scipy import special
+
+def gammaln(x):
+    if isinstance(x, numpy.ndarray):
+        assert all(x > 0)
+    else:
+        assert x > 0
+    return special.gammaln(x)
 
 class DefaultDict(dict):
     def __init__(self, v):


### PR DESCRIPTION
`spicy.special.gammaln(x)` is defined as `ln(abs(gamma(x)))`. Thus, it provides real valued results for non-positive values of `x` even though the `gamma` function returns complex results for negative numbers. I modified `gammaln` to do range checking, and I always get an error when running `self.sequence_random(0.2, 0.01, 0.5, 0)` in `test_hdplda2.py` because `n_k` contains negative values. 

My guess is that this indicates `calc_posterior_t` contains a bug somewhere, but I'm unclear as to what it might be. 